### PR TITLE
-Add Coroutine suspend functions for calling service in background or…

### DIFF
--- a/k4kotlin-retrofit/build.gradle
+++ b/k4kotlin-retrofit/build.gradle
@@ -34,7 +34,13 @@ dependencies {
     // retrofit
     implementation "com.squareup.retrofit2:retrofit:2.3.0"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+
+    //coroutine
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.19.3'
+
 }
 repositories {
     mavenCentral()
 }
+
+apply plugin: 'kotlin-android-extensions'

--- a/k4kotlin-retrofit/src/main/java/com/livinglifetechway/k4kotlin_retrofit/Retrofit.kt
+++ b/k4kotlin-retrofit/src/main/java/com/livinglifetechway/k4kotlin_retrofit/Retrofit.kt
@@ -4,8 +4,10 @@ import android.arch.lifecycle.Lifecycle
 import android.arch.lifecycle.LifecycleObserver
 import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.OnLifecycleEvent
+import kotlinx.coroutines.experimental.CompletableDeferred
 import retrofit2.Call
 import retrofit2.Callback
+import retrofit2.Response
 
 /**
  * Excepts the an object of lifecycle owner (activity,fragment etc) as the first argument so that,
@@ -24,4 +26,115 @@ fun <T> Call<T>.enqueue(lifecycleOwner: LifecycleOwner, callback: Callback<T>) {
         }
     })
     this.enqueue(callback)
+}
+
+
+/**
+ *
+ */
+suspend fun <T> Call<T>.enqueueAwait(lifeCycleOwner: LifecycleOwner? = null, callback: Callback<T>? = null): T {
+
+    val deferred = CompletableDeferred<T>()
+
+    deferred.invokeOnCompletion {
+        if (deferred.isCancelled) {
+            this.cancel()
+        }
+    }
+
+    lifeCycleOwner?.lifecycle?.addObserver(object : LifecycleObserver {
+        @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        fun cancelCalls() {
+            this@enqueueAwait.cancel()
+        }
+    })
+
+    this.enqueue(object : Callback<T> {
+        override fun onFailure(call: Call<T>?, t: Throwable?) {
+            callback?.onFailure(call, t)
+            deferred.completeExceptionally(t!!)
+        }
+
+        override fun onResponse(call: Call<T>?, response: Response<T>?) {
+            callback?.onResponse(call, response)
+            deferred.complete(response?.body()!!)
+        }
+
+    })
+
+    return deferred.await()
+}
+
+
+/**
+ *
+ */
+suspend fun <T> Call<T>.enqueueDeferred(lifeCycleOwner: LifecycleOwner? = null, callback: Callback<T>? = null): CompletableDeferred<T> {
+
+    val deferred = CompletableDeferred<T>()
+
+    deferred.invokeOnCompletion {
+        if (deferred.isCancelled) {
+            this.cancel()
+        }
+    }
+
+    lifeCycleOwner?.lifecycle?.addObserver(object : LifecycleObserver {
+        @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        fun cancelCalls() {
+            this@enqueueDeferred.cancel()
+        }
+    })
+
+    this.enqueue(object : Callback<T> {
+        override fun onFailure(call: Call<T>?, t: Throwable?) {
+            callback?.onFailure(call, t)
+            deferred.completeExceptionally(t!!)
+        }
+
+        override fun onResponse(call: Call<T>?, response: Response<T>?) {
+            callback?.onResponse(call, response)
+            deferred.complete(response?.body()!!)
+        }
+
+    })
+
+    return deferred
+}
+
+
+/**
+ *
+ */
+suspend fun <T> Call<T>.enqueueDeferredResponse(lifeCycleOwner: LifecycleOwner? = null, callback: Callback<T>? = null): CompletableDeferred<Response<T>> {
+
+    val deferred = CompletableDeferred<Response<T>>()
+
+    deferred.invokeOnCompletion {
+        if (deferred.isCancelled) {
+            this.cancel()
+        }
+    }
+
+    lifeCycleOwner?.lifecycle?.addObserver(object : LifecycleObserver {
+        @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        fun cancelCalls() {
+            this@enqueueDeferredResponse.cancel()
+        }
+    })
+
+    this.enqueue(object : Callback<T> {
+        override fun onFailure(call: Call<T>?, t: Throwable?) {
+            callback?.onFailure(call, t)
+            deferred.completeExceptionally(t!!)
+        }
+
+        override fun onResponse(call: Call<T>?, response: Response<T>?) {
+            callback?.onResponse(call, response)
+            deferred.complete(response!!)
+        }
+
+    })
+
+    return deferred
 }


### PR DESCRIPTION
… concurrently with UI,

-in which, enqueueAwait() wait for response and then return response,
-enqueueDeferred() returns Deferred<T> which can be used as deferredValue.await() which can wait for response,
-enqueueDeferredResponse() returns Deferred<Response<T>> which can used to get original response object return by the retrofit